### PR TITLE
Update Levenshtein to not use recalled version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy==1.19.4
 opencv-python-headless==4.4.0.46
 psycopg2-binary==2.8.6
 python-dotenv==0.15.0
-python-Levenshtein==0.12.0
+python-Levenshtein==0.12.1
 SQLAlchemy==1.3.22
 Unidecode==1.1.1
 validators==0.18.1


### PR DESCRIPTION
Very minor edit; updating reqs to point to the latest version of Levenshtein. 12.0 was recalled for security issues. No functionality issues that I noticed, but since it's a bunch of bug fixes for memory issues/overruns/etc, it's possible.

Details: https://pypi.org/project/python-Levenshtein/#id1